### PR TITLE
Fix typo for POSTGRESQL_DATABASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The Bitnami PgBouncer container requires a running PostgreSQL installation to co
 
 - `POSTGRESQL_USERNAME`: Backend PostgreSQL username. Default: **postgres**.
 - `POSTGRESQL_PASSWORD`: Backend PostgreSQL password. No defaults.
-- `POSTGRESQL_PASSWORD`: Backend PostgreSQL Database name to connect to. Default: **postgres**.
+- `POSTGRESQL_DATABASE`: Backend PostgreSQL Database name to connect to. Default: **postgres**.
 - `POSTGRESQL_HOST`: Backend PostgreSQL hostname. Default: **postgresql**.
 - `POSTGRESQL_PORT`: Backend PostgreSQL port. Default: **5432**.
 


### PR DESCRIPTION
**Description of the change**

Typo fix in readme:

```
POSTGRESQL_PASSWORD: Backend PostgreSQL Database name to connect to. Default: postgres.
```

**Benefits**



**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

None
