### PR TITLE
Issue 6 - support for setting `ignore_startup_parameters` via env var

### DIFF
--- a/1/debian-10/rootfs/opt/bitnami/scripts/libpgbouncer.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/libpgbouncer.sh
@@ -198,6 +198,7 @@ pgbouncer_initialize() {
         ini-file set --section "pgbouncer" --key "logfile" --value "$PGBOUNCER_LOG_FILE" "$PGBOUNCER_CONF_FILE"
         ini-file set --section "pgbouncer" --key "admin_users" --value "$POSTGRESQL_USERNAME" "$PGBOUNCER_CONF_FILE"
         ini-file set --section "pgbouncer" --key "client_tls_sslmode" --value "$PGBOUNCER_CLIENT_TLS_SSLMODE" "$PGBOUNCER_CONF_FILE"
+        ini-file set --section "pgbouncer" --key "ignore_startup_parameters" --value "$PGBOUNCER_IGNORE_STARTUP_PARAMETERS" "$PGBOUNCER_CONF_FILE"
         if [[ "$PGBOUNCER_CLIENT_TLS_SSLMODE" != "disable" ]]; then
             ini-file set --section "pgbouncer" --key "client_tls_cert_file" --value "$PGBOUNCER_CLIENT_TLS_CERT_FILE" "$PGBOUNCER_CONF_FILE"
             ini-file set --section "pgbouncer" --key "client_tls_key_file" --value "$PGBOUNCER_CLIENT_TLS_KEY_FILE" "$PGBOUNCER_CONF_FILE"

--- a/1/debian-10/rootfs/opt/bitnami/scripts/libpgbouncer.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/libpgbouncer.sh
@@ -198,7 +198,7 @@ pgbouncer_initialize() {
         ini-file set --section "pgbouncer" --key "logfile" --value "$PGBOUNCER_LOG_FILE" "$PGBOUNCER_CONF_FILE"
         ini-file set --section "pgbouncer" --key "admin_users" --value "$POSTGRESQL_USERNAME" "$PGBOUNCER_CONF_FILE"
         ini-file set --section "pgbouncer" --key "client_tls_sslmode" --value "$PGBOUNCER_CLIENT_TLS_SSLMODE" "$PGBOUNCER_CONF_FILE"
-        if [[ -n "$PGBOUNCER_IGNORE_STARTUP_PARAMETERS" ]]; then
+        if ! is_empty_value "$PGBOUNCER_IGNORE_STARTUP_PARAMETERS"; then
             ini-file set --section "pgbouncer" --key "ignore_startup_parameters" --value "$PGBOUNCER_IGNORE_STARTUP_PARAMETERS" "$PGBOUNCER_CONF_FILE"
         fi
         if [[ "$PGBOUNCER_CLIENT_TLS_SSLMODE" != "disable" ]]; then

--- a/1/debian-10/rootfs/opt/bitnami/scripts/libpgbouncer.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/libpgbouncer.sh
@@ -198,7 +198,9 @@ pgbouncer_initialize() {
         ini-file set --section "pgbouncer" --key "logfile" --value "$PGBOUNCER_LOG_FILE" "$PGBOUNCER_CONF_FILE"
         ini-file set --section "pgbouncer" --key "admin_users" --value "$POSTGRESQL_USERNAME" "$PGBOUNCER_CONF_FILE"
         ini-file set --section "pgbouncer" --key "client_tls_sslmode" --value "$PGBOUNCER_CLIENT_TLS_SSLMODE" "$PGBOUNCER_CONF_FILE"
-        ini-file set --section "pgbouncer" --key "ignore_startup_parameters" --value "$PGBOUNCER_IGNORE_STARTUP_PARAMETERS" "$PGBOUNCER_CONF_FILE"
+        if [[ -n "$PGBOUNCER_IGNORE_STARTUP_PARAMETERS" ]]; then
+            ini-file set --section "pgbouncer" --key "ignore_startup_parameters" --value "$PGBOUNCER_IGNORE_STARTUP_PARAMETERS" "$PGBOUNCER_CONF_FILE"
+        fi
         if [[ "$PGBOUNCER_CLIENT_TLS_SSLMODE" != "disable" ]]; then
             ini-file set --section "pgbouncer" --key "client_tls_cert_file" --value "$PGBOUNCER_CLIENT_TLS_CERT_FILE" "$PGBOUNCER_CONF_FILE"
             ini-file set --section "pgbouncer" --key "client_tls_key_file" --value "$PGBOUNCER_CLIENT_TLS_KEY_FILE" "$PGBOUNCER_CONF_FILE"

--- a/1/debian-10/rootfs/opt/bitnami/scripts/pgbouncer-env.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/pgbouncer-env.sh
@@ -21,6 +21,7 @@ export BITNAMI_DEBUG="${BITNAMI_DEBUG:-false}"
 # By setting an environment variable matching *_FILE to a file path, the prefixed environment
 # variable will be overridden with the value specified in that file
 pgbouncer_env_vars=(
+    PGBOUNCER_IGNORE_STARTUP_PARAMETERS
     PGBOUNCER_PORT
     PGBOUNCER_LISTEN_ADDRESS
     PGBOUNCER_AUTH_TYPE
@@ -73,6 +74,7 @@ export PGBOUNCER_AUTH_TYPE="${PGBOUNCER_AUTH_TYPE:-md5}"
 export PGBOUNCER_INIT_SLEEP_TIME="${PGBOUNCER_INIT_SLEEP_TIME:-10}"
 export PGBOUNCER_INIT_MAX_RETRIES="${PGBOUNCER_INIT_MAX_RETRIES:-10}"
 export PGBOUNCER_EXTRA_FLAGS="${PGBOUNCER_EXTRA_FLAGS:-}"
+export PGBOUNCER_IGNORE_STARTUP_PARAMETERS="${PGBOUNCER_IGNORE_STARTUP_PARAMETERS:-}"
 
 # TLS settings
 export PGBOUNCER_CLIENT_TLS_SSLMODE="${PGBOUNCER_CLIENT_TLS_SSLMODE:-disable}"

--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ $ docker run --name pgbouncer \
   bitnami/pgbouncer:latest
 ```
 
+## Other options
+
+- `PGBOUNCER_IGNORE_STARTUP_PARAMETERS`: you can use this to set `ignore_startup_parameters` in the auto-generated `pgbouncer.ini`. This can be useful for solving certain connection issues. See https://www.pgbouncer.org/config.html for more details.
+
+
 ## Initializing a new instance
 
 When the container is launched, it will execute the files with extension `.sh` located at `/docker-entrypoint-initdb.d`.


### PR DESCRIPTION
**Description of the change**

Fixes #6.

This PR updates some of the image scripts to add support for a new environment variable `PGBOUNCER_IGNORE_STARTUP_PARAMETERS`.  This environment variable is used to set `ignore_startup_parameters` in the auto-generated `pgbouncer.ini`.

**Benefits**

As mentioned in the issue, some JDBC connectors can have trouble connecting to pgbouncer because pgbouncer throws an error on unrecognized parameters in startup packets.  The result of this is that some DB tools can't connect to pgbouncer running in the bitnami-docker-pgbouncer image, and there's no easy way to fix it.

By exposing the option to set `ignore_startup_parameters` via environment variable, its easy to fix these connection issues without having to build a customer docker image on top of bitnami-docker-pgbouncer.

**Possible drawbacks**

None that I can think of.

**Applicable issues**

#6

**Additional information**

You can see screenshots here of "before" and "after" the fix, by running the original and the modified bitnami-docker-pgbouncer images in a minikube cluster on my laptop.

before:

![Screenshot from 2021-06-20 20-49-32](https://user-images.githubusercontent.com/1326765/122685478-e4cc4e80-d20b-11eb-9014-241665d86c89.png)
![Screenshot from 2021-06-20 20-50-06](https://user-images.githubusercontent.com/1326765/122685482-e9910280-d20b-11eb-807e-133ef8a2487b.png)
![Screenshot from 2021-06-20 20-50-13](https://user-images.githubusercontent.com/1326765/122685484-ed248980-d20b-11eb-821e-fac241b75a63.png)

after:

![Screenshot from 2021-06-20 20-51-47](https://user-images.githubusercontent.com/1326765/122685495-fb72a580-d20b-11eb-9d73-861f8ba4a781.png)
![Screenshot from 2021-06-20 20-51-54](https://user-images.githubusercontent.com/1326765/122685498-fe6d9600-d20b-11eb-889a-ea3d6eebf54e.png)
![Screenshot from 2021-06-20 20-51-58](https://user-images.githubusercontent.com/1326765/122685500-00375980-d20c-11eb-9767-02d1e44d7fe8.png)

