### PR TITLE
Correct client-side database name in pgbouncer.ini

### DIFF
--- a/1/debian-10/rootfs/opt/bitnami/scripts/libpgbouncer.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/libpgbouncer.sh
@@ -189,7 +189,7 @@ pgbouncer_initialize() {
     info "Creating configuration file"
     # Create configuration
     if ! pgbouncer_is_file_external "pgbouncer.ini"; then
-        ini-file set --section "databases" --key "postgres" --value "host=$POSTGRESQL_HOST port=$POSTGRESQL_PORT dbname=$POSTGRESQL_DATABASE" "$PGBOUNCER_CONF_FILE"
+        ini-file set --section "databases" --key "$POSTGRESQL_DATABASE" --value "host=$POSTGRESQL_HOST port=$POSTGRESQL_PORT dbname=$POSTGRESQL_DATABASE" "$PGBOUNCER_CONF_FILE"
         ini-file set --section "pgbouncer" --key "listen_port" --value "$PGBOUNCER_PORT" "$PGBOUNCER_CONF_FILE"
         ini-file set --section "pgbouncer" --key "listen_addr" --value "$PGBOUNCER_LISTEN_ADDRESS" "$PGBOUNCER_CONF_FILE"
         ini-file set --section "pgbouncer" --key "auth_file" --value "$PGBOUNCER_AUTH_FILE" "$PGBOUNCER_CONF_FILE"


### PR DESCRIPTION
When setting `POSTGRESQL_DATABASE` to `mydatabasename` the `pgbouncer.ini` file is currently generated like this:

```
[databases]
postgres=host=pgbouncer-backend port=5432 dbname=mydatabasename

[pgbouncer]
...
```

This results in client-side connections to `mydatabasename` failing with an error:

```
$ PGPASSWORD=mypassword psql -h mypgbouncer -U myusername -p 6432 mydatabasename
psql: error: ERROR:  no such database: mydatabasename
```

PGBouncer documentation states:
> …the key will be taken as a database name and the value as a libpq connection string…

This means that pgbouncer will publish the database on a different name (`postgres`) than the one it's connecting to (`mydatabasename`) leading to confusion. In my case, we're overriding the entire `pgbouncer.ini` file by mounting a custom config in order to correct this.

Net effects of this change are the line will be correctly generated when a custom database name is specified, allowing connections to succeed as a user would expect:

```
[databases]
mydatabasename=host=pgbouncer-backend port=5432 dbname=mydatabasename

[pgbouncer]
...
```

Potential downsides include backwards incompatibility for those relying on the existing poor behavior. I.e. if one is specifying a custom `POSTGRESQL_DATABASE` name and has adjusted their application connection string to connect using dbname of `postgres` to workaround this bug, their application config will require re-adjusting to correctly use the custom dbname value following this change.