### PR TITLE
Wrong name of pgbouncer.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Alternatively, you may also provide this configuration in your [custom](https://
 
 ## Configuration file
 
-The image looks for `pgbouncer.conf` file in `/opt/bitnami/pgbouncer/conf/`. You can mount a volume at `/bitnami/pgbouncer/conf/` and copy/edit the `pgbouncer.conf` file in the `/path/to/pgbouncer-persistence/conf/`. The default configurations will be populated to the `conf/` directory if it's empty.
+The image looks for `pgbouncer.ini` file in `/opt/bitnami/pgbouncer/conf/`. You can mount a volume at `/bitnami/pgbouncer/conf/` and copy/edit the `pgbouncer.ini` file in the `/path/to/pgbouncer-persistence/conf/`. The default configurations will be populated to the `conf/` directory if it's empty.
 
 ```console
 /path/to/pgbouncer-persistence/conf/


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
The readme says the pgbouncer configuration file should be named pgbouncer.conf but according to the code it should be pgbouncer.ini

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
Loads the right configuration file upon start

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
People might have made hacks to succeed in using pgbouncer.ini (wrongly named pgbouncer.conf)

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
