### PR TITLE
Fix wrong validation for server_tls_sslmode

### DIFF
--- a/1/debian-10/rootfs/opt/bitnami/scripts/libpgbouncer.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/libpgbouncer.sh
@@ -263,11 +263,11 @@ pgbouncer_initialize() {
         fi
 
         if [[ "$PGBOUNCER_SERVER_TLS_SSLMODE" != "disable" ]]; then
-            ! is_empty_value ini-file set --section "pgbouncer" --key "server_tls_cert_file" --value "$PGBOUNCER_SERVER_TLS_CERT_FILE" "$PGBOUNCER_CONF_FILE"
+            ! is_empty_value "$PGBOUNCER_SERVER_TLS_CERT_FILE" && ini-file set --section "pgbouncer" --key "server_tls_cert_file" --value "$PGBOUNCER_SERVER_TLS_CERT_FILE" "$PGBOUNCER_CONF_FILE"
             ! is_empty_value ini-file set --section "pgbouncer" --key "server_tls_key_file" --value "$PGBOUNCER_SERVER_TLS_KEY_FILE" "$PGBOUNCER_CONF_FILE"
             ! is_empty_value "$PGBOUNCER_SERVER_TLS_CA_FILE" && ini-file set --section "pgbouncer" --key "server_tls_ca_file" --value "$PGBOUNCER_SERVER_TLS_CA_FILE" "$PGBOUNCER_CONF_FILE"
             ! is_empty_value "$PGBOUNCER_SERVER_TLS_PROTOCOLS" && ini-file set --section "pgbouncer" --key "server_tls_protocols" --value "$PGBOUNCER_SERVER_TLS_PROTOCOLS" "$PGBOUNCER_CONF_FILE"
-            ! is_empty_value ini-file set --section "pgbouncer" --key "server_tls_ciphers" --value "$PGBOUNCER_SERVER_TLS_CIPHERS" "$PGBOUNCER_CONF_FILE"
+            ! is_empty_value "$PGBOUNCER_SERVER_TLS_CIPHERS" && ini-file set --section "pgbouncer" --key "server_tls_ciphers" --value "$PGBOUNCER_SERVER_TLS_CIPHERS" "$PGBOUNCER_CONF_FILE"
         fi
     else
         debug "Configuration file is mounted externally, skipping configuration"

--- a/1/debian-10/rootfs/opt/bitnami/scripts/libpgbouncer.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/libpgbouncer.sh
@@ -263,11 +263,11 @@ pgbouncer_initialize() {
         fi
 
         if [[ "$PGBOUNCER_SERVER_TLS_SSLMODE" != "disable" ]]; then
-            ini-file set --section "pgbouncer" --key "server_tls_cert_file" --value "$PGBOUNCER_SERVER_TLS_CERT_FILE" "$PGBOUNCER_CONF_FILE"
-            ini-file set --section "pgbouncer" --key "server_tls_key_file" --value "$PGBOUNCER_SERVER_TLS_KEY_FILE" "$PGBOUNCER_CONF_FILE"
+            ! is_empty_value ini-file set --section "pgbouncer" --key "server_tls_cert_file" --value "$PGBOUNCER_SERVER_TLS_CERT_FILE" "$PGBOUNCER_CONF_FILE"
+            ! is_empty_value ini-file set --section "pgbouncer" --key "server_tls_key_file" --value "$PGBOUNCER_SERVER_TLS_KEY_FILE" "$PGBOUNCER_CONF_FILE"
             ! is_empty_value "$PGBOUNCER_SERVER_TLS_CA_FILE" && ini-file set --section "pgbouncer" --key "server_tls_ca_file" --value "$PGBOUNCER_SERVER_TLS_CA_FILE" "$PGBOUNCER_CONF_FILE"
             ! is_empty_value "$PGBOUNCER_SERVER_TLS_PROTOCOLS" && ini-file set --section "pgbouncer" --key "server_tls_protocols" --value "$PGBOUNCER_SERVER_TLS_PROTOCOLS" "$PGBOUNCER_CONF_FILE"
-            ini-file set --section "pgbouncer" --key "server_tls_ciphers" --value "$PGBOUNCER_SERVER_TLS_CIPHERS" "$PGBOUNCER_CONF_FILE"
+            ! is_empty_value ini-file set --section "pgbouncer" --key "server_tls_ciphers" --value "$PGBOUNCER_SERVER_TLS_CIPHERS" "$PGBOUNCER_CONF_FILE"
         fi
     else
         debug "Configuration file is mounted externally, skipping configuration"

--- a/1/debian-10/rootfs/opt/bitnami/scripts/libpgbouncer.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/libpgbouncer.sh
@@ -264,7 +264,7 @@ pgbouncer_initialize() {
 
         if [[ "$PGBOUNCER_SERVER_TLS_SSLMODE" != "disable" ]]; then
             ! is_empty_value "$PGBOUNCER_SERVER_TLS_CERT_FILE" && ini-file set --section "pgbouncer" --key "server_tls_cert_file" --value "$PGBOUNCER_SERVER_TLS_CERT_FILE" "$PGBOUNCER_CONF_FILE"
-            ! is_empty_value ini-file set --section "pgbouncer" --key "server_tls_key_file" --value "$PGBOUNCER_SERVER_TLS_KEY_FILE" "$PGBOUNCER_CONF_FILE"
+            ! is_empty_value "$PGBOUNCER_SERVER_TLS_KEY_FILE" && ini-file set --section "pgbouncer" --key "server_tls_key_file" --value "$PGBOUNCER_SERVER_TLS_KEY_FILE" "$PGBOUNCER_CONF_FILE"
             ! is_empty_value "$PGBOUNCER_SERVER_TLS_CA_FILE" && ini-file set --section "pgbouncer" --key "server_tls_ca_file" --value "$PGBOUNCER_SERVER_TLS_CA_FILE" "$PGBOUNCER_CONF_FILE"
             ! is_empty_value "$PGBOUNCER_SERVER_TLS_PROTOCOLS" && ini-file set --section "pgbouncer" --key "server_tls_protocols" --value "$PGBOUNCER_SERVER_TLS_PROTOCOLS" "$PGBOUNCER_CONF_FILE"
             ! is_empty_value "$PGBOUNCER_SERVER_TLS_CIPHERS" && ini-file set --section "pgbouncer" --key "server_tls_ciphers" --value "$PGBOUNCER_SERVER_TLS_CIPHERS" "$PGBOUNCER_CONF_FILE"

--- a/1/debian-10/rootfs/opt/bitnami/scripts/libpgbouncer.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/libpgbouncer.sh
@@ -112,7 +112,7 @@ pgbouncer_validate() {
             elif [[ ! -f "$PGBOUNCER_SERVER_TLS_CA_FILE" ]]; then
                 print_validation_error "The server CA X.509 certificate file in the specified path ${PGBOUNCER_SERVER_TLS_CA_FILE} does not exist"
             fi
-        elif
+        else
             if [[ -z "$PGBOUNCER_SERVER_TLS_CA_FILE" ]]; then
                 print_validation_error "A CA X.509 certificate was not provided. You need to set this value when specifying server_tls_sslmode to verify-ca or verify-full"
             elif [[ ! -f "$PGBOUNCER_SERVER_TLS_CA_FILE" ]]; then

--- a/1/debian-10/rootfs/opt/bitnami/scripts/libpgbouncer.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/libpgbouncer.sh
@@ -96,20 +96,28 @@ pgbouncer_validate() {
 
     # TLS Checks (server)
     if [[ "$PGBOUNCER_SERVER_TLS_SSLMODE" != "disable" ]]; then
-        if [[ -z "$PGBOUNCER_SERVER_TLS_CERT_FILE" ]]; then
-            print_validation_error "You must provide a X.509 certificate in order to use server TLS"
-        elif [[ ! -f "$PGBOUNCER_SERVER_TLS_CERT_FILE" ]]; then
-            print_validation_error "The X.509 server certificate file in the specified path ${PGBOUNCER_SERVER_TLS_CERT_FILE} does not exist"
-        fi
-        if [[ -z "$PGBOUNCER_SERVER_TLS_KEY_FILE" ]]; then
-            print_validation_error "You must provide a private key in order to use server TLS"
-        elif [[ ! -f "$PGBOUNCER_SERVER_TLS_KEY_FILE" ]]; then
-            print_validation_error "The server private key file in the specified path ${PGBOUNCER_SERVER_TLS_KEY_FILE} does not exist"
-        fi
-        if [[ -z "$PGBOUNCER_SERVER_TLS_CA_FILE" ]]; then
-            warn "A CA X.509 certificate was not provided. Server verification will not be performed in TLS connections"
-        elif [[ ! -f "$PGBOUNCER_SERVER_TLS_CA_FILE" ]]; then
-            print_validation_error "The server CA X.509 certificate file in the specified path ${PGBOUNCER_SERVER_TLS_CA_FILE} does not exist"
+        if [[ "$PGBOUNCER_SERVER_TLS_SSLMODE" != "verify-ca" && "$PGBOUNCER_SERVER_TLS_SSLMODE" != "verify-full" ]]; then 
+            if [[ -z "$PGBOUNCER_SERVER_TLS_CERT_FILE" ]]; then
+                print_validation_error "You must provide a X.509 certificate in order to use server TLS"
+            elif [[ ! -f "$PGBOUNCER_SERVER_TLS_CERT_FILE" ]]; then
+                print_validation_error "The X.509 server certificate file in the specified path ${PGBOUNCER_SERVER_TLS_CERT_FILE} does not exist"
+            fi
+            if [[ -z "$PGBOUNCER_SERVER_TLS_KEY_FILE" ]]; then
+                print_validation_error "You must provide a private key in order to use server TLS"
+            elif [[ ! -f "$PGBOUNCER_SERVER_TLS_KEY_FILE" ]]; then
+                print_validation_error "The server private key file in the specified path ${PGBOUNCER_SERVER_TLS_KEY_FILE} does not exist"
+            fi
+            if [[ -z "$PGBOUNCER_SERVER_TLS_CA_FILE" ]]; then
+                warn "A CA X.509 certificate was not provided. Server verification will not be performed in TLS connections"
+            elif [[ ! -f "$PGBOUNCER_SERVER_TLS_CA_FILE" ]]; then
+                print_validation_error "The server CA X.509 certificate file in the specified path ${PGBOUNCER_SERVER_TLS_CA_FILE} does not exist"
+            fi
+        elif
+            if [[ -z "$PGBOUNCER_SERVER_TLS_CA_FILE" ]]; then
+                print_validation_error "A CA X.509 certificate was not provided. You need to set this value when specifying server_tls_sslmode to verify-ca or verify-full"
+            elif [[ ! -f "$PGBOUNCER_SERVER_TLS_CA_FILE" ]]; then
+                print_validation_error "The server CA X.509 certificate file in the specified path ${PGBOUNCER_SERVER_TLS_CA_FILE} does not exist"
+            fi
         fi
     fi
 


### PR DESCRIPTION
**Description of the change**

Fixes validation for server_tls_key_file and server_tls_cert_file which are not required when setting server_tls_sslmode to verify-ca and verify-full. This is needed to connect to Azure Database for PostgresSQL for example.
