### PR TITLE
fix: add server_reset_query and server_idle_timeout

### DIFF
--- a/1/debian-11/rootfs/opt/bitnami/scripts/libpgbouncer.sh
+++ b/1/debian-11/rootfs/opt/bitnami/scripts/libpgbouncer.sh
@@ -237,6 +237,8 @@ pgbouncer_initialize() {
             "max_client_conn:${PGBOUNCER_MAX_CLIENT_CONN}"
             "max_db_connections:${PGBOUNCER_MAX_DB_CONNECTIONS}"
             "idle_transaction_timeout:${PGBOUNCER_IDLE_TRANSACTION_TIMEOUT}"
+            "server_idle_timeout:${PGBOUNCER_SERVER_IDLE_TIMEOUT}"
+            "server_reset_query:${PGBOUNCER_SERVER_RESET_QUERY}"
             "default_pool_size:${PGBOUNCER_DEFAULT_POOL_SIZE}"
             "min_pool_size:${PGBOUNCER_MIN_POOL_SIZE}"
             "reserve_pool_size:${PGBOUNCER_RESERVE_POOL_SIZE}"


### PR DESCRIPTION
**Description of the change**

 This adds options in connection configuration - server_reset_query and server_idle_timeout

**Benefits**

So you can set this options

**Additional information**

I don't know how bot removed previously added options from https://github.com/bitnami/bitnami-docker-pgbouncer/pull/25 in https://github.com/bitnami/bitnami-docker-pgbouncer/commit/5589907bdefe860c134a85533770ab2a01a1ff3e